### PR TITLE
Added ItemType enum

### DIFF
--- a/Idle.Core/Models/Item.cs
+++ b/Idle.Core/Models/Item.cs
@@ -34,6 +34,7 @@ namespace Idle.Core.Models
         Ancient,
         Forbidden
         }
+        public enum ItemType { GitHubOne, GitHubEnterprise, GitHubPro, GitHubTeam}
 
     }
 }


### PR DESCRIPTION
We have added an ItemType enum to replace the use of nameof()